### PR TITLE
Location name in query

### DIFF
--- a/src/main/java/org/jlab/jaws/presentation/controller/Active.java
+++ b/src/main/java/org/jlab/jaws/presentation/controller/Active.java
@@ -1,7 +1,6 @@
 package org.jlab.jaws.presentation.controller;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.*;
 import javax.ejb.EJB;
 import javax.servlet.ServletException;
@@ -14,7 +13,6 @@ import org.jlab.jaws.business.session.LocationFacade;
 import org.jlab.jaws.business.session.SystemFacade;
 import org.jlab.jaws.persistence.entity.Location;
 import org.jlab.jaws.persistence.entity.SystemEntity;
-import org.jlab.smoothness.presentation.util.ParamConverter;
 
 /**
  * @author ryans
@@ -47,7 +45,9 @@ public class Active extends HttpServlet {
 
     if (locationArray != null && locationArray.length > 0) {
       for (String name : locationArray) {
-        if (name == null || name.isBlank()) { // TODO: the convertBigIntegerArray method should be excluding empty/null
+        if (name == null
+            || name.isBlank()) { // TODO: the convertBigIntegerArray method should be excluding
+          // empty/null
           continue;
         }
 

--- a/src/main/java/org/jlab/jaws/presentation/controller/Active.java
+++ b/src/main/java/org/jlab/jaws/presentation/controller/Active.java
@@ -39,24 +39,24 @@ public class Active extends HttpServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
 
-    BigInteger[] locationIdArray = ParamConverter.convertBigIntegerArray(request, "locationId");
+    String[] locationArray = request.getParameterValues("location");
 
     List<Location> selectedLocationList = new ArrayList<>();
     Set<Location> materializedLocations = new HashSet<>();
     String locationFilterStr = "";
 
-    if (locationIdArray != null && locationIdArray.length > 0) {
-      for (BigInteger id : locationIdArray) {
-        if (id == null) { // TODO: the convertBigIntegerArray method should be excluding empty/null
+    if (locationArray != null && locationArray.length > 0) {
+      for (String name : locationArray) {
+        if (name == null || name.isBlank()) { // TODO: the convertBigIntegerArray method should be excluding empty/null
           continue;
         }
 
-        Location l = locationFacade.find(id);
+        Location l = locationFacade.findByName(name);
         selectedLocationList.add(l);
 
-        locationFilterStr = locationFilterStr + "&locationId=" + id;
+        locationFilterStr = locationFilterStr + "&locationId=" + l.getLocationId();
 
-        Set<Location> subset = locationFacade.findBranchAsSet(id);
+        Set<Location> subset = locationFacade.findBranchAsSet(l.getLocationId());
         materializedLocations.addAll(subset);
       }
     }

--- a/src/main/webapp/WEB-INF/tags/hierarchical-select-option-by-name.tag
+++ b/src/main/webapp/WEB-INF/tags/hierarchical-select-option-by-name.tag
@@ -1,0 +1,16 @@
+<%@tag description="Hierarchical selection option tag" pageEncoding="UTF-8" %>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@taglib prefix="s" uri="http://jlab.org/jsp/smoothness" %>
+<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<%@attribute name="node" required="true" type="org.jlab.jaws.persistence.model.Node" %>
+<%@attribute name="level" required="true" type="java.lang.Integer" %>
+<%@attribute name="parameterName" required="true" type="java.lang.String" %>
+<option value="${node.name}"${s:inArray(paramValues[parameterName], node.name) ? ' selected="selected"' : ''}><c:forEach begin="1"
+                                                                                                      end="${level}">&nbsp;&nbsp;&nbsp;&nbsp;</c:forEach><c:out
+        value="${node.name}"/></option>
+<c:forEach items="${node.children}" var="child">
+    <t:hierarchical-select-option-by-name node="${child}" level="${level + 1}" parameterName="${parameterName}"/>
+</c:forEach>
+

--- a/src/main/webapp/WEB-INF/views/active.jsp
+++ b/src/main/webapp/WEB-INF/views/active.jsp
@@ -66,10 +66,10 @@
                                         <label for="location-select">Location</label>
                                     </div>
                                     <div class="li-value">
-                                        <select id="location-select" name="locationId" multiple="multiple">
+                                        <select id="location-select" name="location" multiple="multiple">
                                             <c:forEach items="${locationRoot.children}" var="child">
-                                                <t:hierarchical-select-option node="${child}" level="0"
-                                                                              parameterName="locationId"/>
+                                                <t:hierarchical-select-option-by-name node="${child}" level="0"
+                                                                                      parameterName="location"/>
                                             </c:forEach>
                                         </select>
                                     </div>


### PR DESCRIPTION
Use location name instead of id on active tab URL to make it easier for users

Note: Would be nice to rewrite the URL so location param is a path component, but since location is multi-valued, this won't work so well.  Would need to be single valued, but token-separated instead of multi-valued.   Commas would be intuitive, but not allowed in URI path so would need to use less intuitive separator token.  Maybe later.